### PR TITLE
ESLint config may be too strict

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "browser": true,
     "es2021": true,
-    "jest": true
+    "jest": true,
+    "node": true
   },
   "extends": [
     "standard",
@@ -14,6 +15,11 @@
     "sourceType": "module"
   },
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "no-unmodified-loop-condition": "off"
+  },  
+  "globals": {
+    "document": "readonly",
+    "window": "readonly"
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
     "singleQuote": true,
     "trailingComma": "es5",
     "tabWidth": 2,
-    "semi": true
+    "semi": true,
+    "endOfLine": "auto"
   }

--- a/controllers/webscrapeController.js
+++ b/controllers/webscrapeController.js
@@ -26,7 +26,6 @@ async function scrapeEspn(startDate, endDate, res) {
 
     const current = new Date(start);
 
-    // eslint-disable-next-line no-unmodified-loop-condition
     while (current <= end) {
       const year = current.getFullYear();
       const month = String(current.getMonth() + 1).padStart(2, '0');

--- a/controllers/webscrapeController.js
+++ b/controllers/webscrapeController.js
@@ -26,6 +26,7 @@ async function scrapeEspn(startDate, endDate, res) {
 
     const current = new Date(start);
 
+    // eslint-disable-next-line no-unmodified-loop-condition
     while (current <= end) {
       const year = current.getFullYear();
       const month = String(current.getMonth() + 1).padStart(2, '0');


### PR DESCRIPTION
Modified ESLint and Prettier rules to avoid these problems:
 error  Delete `␍`                              prettier/prettier
 error  'current' is not modified in this loop  no-unmodified-loop-condition
 error  'end' is not modified in this loop      no-unmodified-loop-condition